### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This is the code for FRC Team 5549's robot 2020 Season: Infinite Recharge
 3. Deploy code to the robot using `py -3 robot.py deploy`. Add `--no-version-check` to the end you are deploying during the offseason.
 
 Optional: Feel free to use the deploy scripts found [here](https://github.com/FRC5549Robotics).
+[![Run on Repl.it](https://repl.it/badge/github/FRC5549Robotics/5549-2020)](https://repl.it/github/FRC5549Robotics/5549-2020)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jetthan12/5549-2029).